### PR TITLE
Adding usability wins

### DIFF
--- a/NvidiaDisplayController/Bootstrap/Bootstrapper.cs
+++ b/NvidiaDisplayController/Bootstrap/Bootstrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Threading;
@@ -16,12 +17,38 @@ using NvidiaDisplayController.Interface.Shell;
 using NvidiaDisplayController.Objects.Factories;
 using NvidiaDisplayController.Objects.Factories.Interfaces;
 using LogManager = NLog.LogManager;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace NvidiaDisplayController.Bootstrap;
 
 public class Bootstrapper : BootstrapperBase
 {
     private readonly IKernel _kernel;
+
+    // Used for Window Management
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    // Used for cross process communication 
+    [DllImport("user32.dll")]
+    private static extern bool PostMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
+
+    // custom message
+    private const int WM_SHOWME = 0x0400 + 1; // WM_USER + 1
+    
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    private const int SW_RESTORE = 9;
 
     public Bootstrapper()
     {
@@ -76,19 +103,46 @@ public class Bootstrapper : BootstrapperBase
 
     private Result CheckIfApplicationIsRunning()
     {
-        if (Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName).Length <= 1)
+        var currentProcess = Process.GetCurrentProcess();
+        var existingProcess = Process.GetProcessesByName(currentProcess.ProcessName)
+                                    .FirstOrDefault(p => p.Id != currentProcess.Id);
+
+        // if there's no other process of this running, we continue
+        if (existingProcess == null) return Result.Ok();
+
+        // if we find an existing process, find the window and bring it to the front
+        IntPtr foundHandle = IntPtr.Zero;
+
+        // we need to partial match since the window title changes based on GPU
+        EnumWindows((hWnd, lParam) =>
         {
-            _fileLogger.Info("Starting Application.");
-            return Result.Ok();
+            StringBuilder sb = new StringBuilder(256);
+            GetWindowText(hWnd, sb, sb.Capacity);
+            string title = sb.ToString();
+
+            if (title.StartsWith("Adjust Displays")) 
+            {
+                foundHandle = hWnd;
+                return false; 
+            }
+            return true;
+        }, IntPtr.Zero);
+
+        if (foundHandle != IntPtr.Zero)
+        {
+            _fileLogger.Info("Found existing window via partial match. Restoring...");
+            ShowWindow(foundHandle, SW_RESTORE);
+            SetForegroundWindow(foundHandle);
+
+            // we can't force the other instance to bring itself to the front
+            // tell it to do it itself
+            PostMessage(foundHandle, WM_SHOWME, IntPtr.Zero, IntPtr.Zero);
+
+            Application.Current.Shutdown();
+            return Result.Fail("Focused existing instance.");
         }
 
-        var message = "Application is already running.";
-
-        _fileLogger.Info(message);
-        MessageBox.Show(message);
-
-        Application.Current.Shutdown();
-        return Result.Fail(message);
+    return Result.Ok();
     }
 
     private Result TryStartNvidia()

--- a/NvidiaDisplayController/Interface/Shell/ShellView.xaml.cs
+++ b/NvidiaDisplayController/Interface/Shell/ShellView.xaml.cs
@@ -10,6 +10,8 @@ using NvidiaDisplayController.Global;
 using NvidiaDisplayController.Global.Controllers;
 using NvidiaDisplayController.Global.Extensions;
 using Application = System.Windows.Application;
+using System.Windows.Interop;
+using System.Windows.Input;
 
 namespace NvidiaDisplayController.Interface.Shell;
 
@@ -25,6 +27,15 @@ public partial class ShellView
 
     [Inject] public DataController DataController { get; set; } = null!;
 
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        // add message handler to listen for messages from other instances of the app
+        HwndSource source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        source.AddHook(WndProc);
+    }
+
     private void Start()
     {
         IoC.BuildUp(this);
@@ -32,6 +43,17 @@ public partial class ShellView
         CreateSystemTrayIcon();
 
         GlobalEvents.UpdateToolTip += OnUpdateToolTip;
+    }
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        // listen for the custom message and show the window contents
+        if (msg == 0x0400 + 1) // WM_SHOWME
+        {
+            DoShow();
+            handled = true;
+        }
+        return IntPtr.Zero;
     }
 
     private void OnUpdateToolTip()
@@ -44,6 +66,11 @@ public partial class ShellView
         _notifyIcon = new NotifyIcon();
         _notifyIcon.Icon = new Icon("Resources/desktop.ico");
         _notifyIcon.Visible = true;
+
+        // show the window when left clicking the tray icon
+        _notifyIcon.MouseClick += (s, e) => { 
+            if (e.Button == MouseButtons.Left) DoShow(); 
+        };
 
         _notifyIcon.ContextMenuStrip = new ContextMenuStrip();
         _notifyIcon.ContextMenuStrip.Items.Add("Show", null, OpenEvent);
@@ -80,10 +107,19 @@ public partial class ShellView
         DoShow();
     }
 
-    private void DoShow()
+    public void DoShow()
     {
         Show();
         WindowState = WindowState.Normal;
+
+        // ensure to focus the window so that it brings it to the front
+        Activate();
+        Focus();
+
+        // toggle topmost to bring it to the front above all other windows
+        // then disable so it behaves normally
+        Topmost = true;
+        Topmost = false;
     }
 
     protected override void OnStateChanged(EventArgs e)

--- a/WindowsDisplayAPI-master/WindowsDisplayAPI/WindowsDisplayAPI.csproj
+++ b/WindowsDisplayAPI-master/WindowsDisplayAPI/WindowsDisplayAPI.csproj
@@ -31,12 +31,6 @@
         <DocumentationFile>..\Release\WindowsDisplayAPI.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference PrivateAssets="all" Include="MSBump" Version="2.3.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
         <Content Include="readme.txt">
             <Pack>true</Pack>
             <PackagePath>\</PackagePath>


### PR DESCRIPTION
Two improvements: 

- When running the app again (say, if I put it in my Taskbar and I click on the icon again), if there is already an existing instance, find that window and bring it to the front. This should work whether the window is opened and not focused, or if the window is hidden and the app is minimized to the tray.

- If the app is running in the tray, left clicking the tray icon should open it. 