### PR TITLE
Add working keyboard shortcuts to profiles. Applies globally

### DIFF
--- a/NvidiaDisplayController/Bootstrap/Bootstrapper.cs
+++ b/NvidiaDisplayController/Bootstrap/Bootstrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Threading;
@@ -16,12 +17,38 @@ using NvidiaDisplayController.Interface.Shell;
 using NvidiaDisplayController.Objects.Factories;
 using NvidiaDisplayController.Objects.Factories.Interfaces;
 using LogManager = NLog.LogManager;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace NvidiaDisplayController.Bootstrap;
 
 public class Bootstrapper : BootstrapperBase
 {
     private readonly IKernel _kernel;
+
+    // Used for Window Management
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    // Used for cross process communication 
+    [DllImport("user32.dll")]
+    private static extern bool PostMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
+
+    // custom message
+    private const int WM_SHOWME = 0x0400 + 1; // WM_USER + 1
+    
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    private const int SW_RESTORE = 9;
 
     public Bootstrapper()
     {
@@ -76,19 +103,46 @@ public class Bootstrapper : BootstrapperBase
 
     private Result CheckIfApplicationIsRunning()
     {
-        if (Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName).Length <= 1)
+        var currentProcess = Process.GetCurrentProcess();
+        var existingProcess = Process.GetProcessesByName(currentProcess.ProcessName)
+                                    .FirstOrDefault(p => p.Id != currentProcess.Id);
+
+        // if there's no other process of this running, we continue
+        if (existingProcess == null) return Result.Ok();
+
+        // if we find an existing process, find the window and bring it to the front
+        IntPtr foundHandle = IntPtr.Zero;
+
+        // we need to partial match since the window title changes based on GPU
+        EnumWindows((hWnd, lParam) =>
         {
-            _fileLogger.Info("Starting Application.");
-            return Result.Ok();
+            StringBuilder sb = new StringBuilder(256);
+            GetWindowText(hWnd, sb, sb.Capacity);
+            string title = sb.ToString();
+
+            if (title.StartsWith("Adjust Displays")) 
+            {
+                foundHandle = hWnd;
+                return false; 
+            }
+            return true;
+        }, IntPtr.Zero);
+
+        if (foundHandle != IntPtr.Zero)
+        {
+            _fileLogger.Info("Found existing window via partial match. Restoring...");
+            ShowWindow(foundHandle, SW_RESTORE);
+            SetForegroundWindow(foundHandle);
+
+            // we can't force the other instance to bring itself to the front
+            // tell it to do it itself
+            PostMessage(foundHandle, WM_SHOWME, IntPtr.Zero, IntPtr.Zero);
+
+            Application.Current.Shutdown();
+            return Result.Fail("Focused existing instance.");
         }
 
-        var message = "Application is already running.";
-
-        _fileLogger.Info(message);
-        MessageBox.Show(message);
-
-        Application.Current.Shutdown();
-        return Result.Fail(message);
+    return Result.Ok();
     }
 
     private Result TryStartNvidia()

--- a/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingView.xaml
+++ b/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingView.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="35" />
             <RowDefinition Height="35" />
             <RowDefinition Height="35" />
+            <RowDefinition Height="35" />
         </Grid.RowDefinitions>
         <Label
             Grid.Row="0"
@@ -159,5 +160,46 @@
             Text="Warning: Very high and very low Brightness and Contrast values can limit the Gamma range."
             VerticalAlignment="Center"
             HorizontalAlignment="Center"/>
+        <Label
+            Grid.Row="3"
+            Grid.Column="0"
+            HorizontalAlignment="Right"
+            Margin="0,0,5,0"
+            VerticalAlignment="Center"
+            Content="Keyboard Shortcut" />
+        <StackPanel
+            Grid.Row="3"
+            Grid.Column="1"
+            Grid.ColumnSpan="3"
+            Orientation="Horizontal"
+            VerticalAlignment="Center">
+            <CheckBox
+                Content="Ctrl"
+                IsChecked="{Binding IsCtrlChecked}"
+                Margin="5,0"
+                VerticalAlignment="Center"/>
+            <CheckBox
+                Content="Alt"
+                IsChecked="{Binding IsAltChecked}"
+                Margin="5,0"
+                VerticalAlignment="Center"/>
+            <CheckBox
+                Content="Shift"
+                IsChecked="{Binding IsShiftChecked}"
+                Margin="5,0"
+                VerticalAlignment="Center"/>
+            <Label Content="+" Margin="5,0" VerticalAlignment="Center"/>
+            <ComboBox
+                Width="100"
+                ItemsSource="{Binding AvailableKeys}"
+                SelectedItem="{Binding SelectedKey}"
+                VerticalAlignment="Center"/>
+            <Button
+                Content="Clear"
+                Margin="10,0"
+                Padding="10,0"
+                Command="{Binding ClearHotkeyCommand}"
+                VerticalAlignment="Center"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingViewModel.cs
+++ b/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingViewModel.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Windows.Input;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Caliburn.Micro;
 using NvidiaDisplayController.Objects.Entities;
 using NvidiaDisplayController.Objects.HandleEvents;
@@ -231,9 +232,8 @@ public class ProfileSettingViewModel : Screen, IHandle<RevertEvent>
 
 public class RelayCommand : ICommand
 {
-    private readonly Action _execute;
-
-    public RelayCommand(Action execute)
+    private readonly System.Action _execute;
+    public RelayCommand(System.Action execute)
     {
         _execute = execute;
     }

--- a/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingViewModel.cs
+++ b/NvidiaDisplayController/Interface/ProfileSettings/ProfileSettingViewModel.cs
@@ -1,5 +1,8 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Caliburn.Micro;
 using NvidiaDisplayController.Objects.Entities;
 using NvidiaDisplayController.Objects.HandleEvents;
@@ -9,22 +12,87 @@ namespace NvidiaDisplayController.Interface.ProfileSettings;
 public class ProfileSettingViewModel : Screen, IHandle<RevertEvent>
 {
     private readonly IEventAggregator _eventAggregator;
+    private readonly Profile _profile;
     private ProfileSetting _originalSettings = null!;
     private bool _resetting;
+    private bool _isCtrlChecked;
+    private bool _isAltChecked;
+    private bool _isShiftChecked;
+    private Key? _selectedKey;
 
-    public ProfileSettingViewModel(ProfileSetting profileSetting, bool isDefault, IEventAggregator eventAggregator)
+    public ProfileSettingViewModel(ProfileSetting profileSetting, bool isDefault, IEventAggregator eventAggregator, Profile profile)
     {
         _eventAggregator = eventAggregator;
+        _profile = profile;
         ProfileSetting = profileSetting;
         IsDefault = isDefault;
 
         SetOriginalSettings(profileSetting);
+        LoadHotkeySettings();
         _eventAggregator.SubscribeOnPublishedThread(this);
     }
 
     public ProfileSetting ProfileSetting { get; }
 
     public bool IsDefault { get; }
+    
+    public List<Key> AvailableKeys { get; } = new()
+    {
+        Key.F1, Key.F2, Key.F3, Key.F4, Key.F5, Key.F6, Key.F7, Key.F8, Key.F9, Key.F10, Key.F11, Key.F12,
+        Key.D0, Key.D1, Key.D2, Key.D3, Key.D4, Key.D5, Key.D6, Key.D7, Key.D8, Key.D9,
+        Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H, Key.I, Key.J, Key.K, Key.L, Key.M,
+        Key.N, Key.O, Key.P, Key.Q, Key.R, Key.S, Key.T, Key.U, Key.V, Key.W, Key.X, Key.Y, Key.Z
+    };
+
+    public bool IsCtrlChecked
+    {
+        get => _isCtrlChecked;
+        set
+        {
+            if (value == _isCtrlChecked) return;
+            _isCtrlChecked = value;
+            NotifyOfPropertyChange();
+            UpdateHotkey();
+        }
+    }
+
+    public bool IsAltChecked
+    {
+        get => _isAltChecked;
+        set
+        {
+            if (value == _isAltChecked) return;
+            _isAltChecked = value;
+            NotifyOfPropertyChange();
+            UpdateHotkey();
+        }
+    }
+
+    public bool IsShiftChecked
+    {
+        get => _isShiftChecked;
+        set
+        {
+            if (value == _isShiftChecked) return;
+            _isShiftChecked = value;
+            NotifyOfPropertyChange();
+            UpdateHotkey();
+        }
+    }
+
+    public Key? SelectedKey
+    {
+        get => _selectedKey;
+        set
+        {
+            if (Equals(value, _selectedKey)) return;
+            _selectedKey = value;
+            NotifyOfPropertyChange();
+            UpdateHotkey();
+        }
+    }
+
+    public ICommand ClearHotkeyCommand => new RelayCommand(ClearHotkey);
 
     public double Brightness
     {
@@ -89,6 +157,60 @@ public class ProfileSettingViewModel : Screen, IHandle<RevertEvent>
         return Task.CompletedTask;
     }
 
+    private void LoadHotkeySettings()
+    {
+        if (_profile.HotkeyModifiers.HasValue)
+        {
+            _isCtrlChecked = (_profile.HotkeyModifiers.Value & ModifierKeys.Control) == ModifierKeys.Control;
+            _isAltChecked = (_profile.HotkeyModifiers.Value & ModifierKeys.Alt) == ModifierKeys.Alt;
+            _isShiftChecked = (_profile.HotkeyModifiers.Value & ModifierKeys.Shift) == ModifierKeys.Shift;
+        }
+        _selectedKey = _profile.HotkeyKey;
+        
+        NotifyOfPropertyChange(nameof(IsCtrlChecked));
+        NotifyOfPropertyChange(nameof(IsAltChecked));
+        NotifyOfPropertyChange(nameof(IsShiftChecked));
+        NotifyOfPropertyChange(nameof(SelectedKey));
+    }
+
+    private void UpdateHotkey()
+    {
+        if (_resetting) return;
+
+        if (_selectedKey.HasValue && (IsCtrlChecked || IsAltChecked || IsShiftChecked))
+        {
+            var modifiers = ModifierKeys.None;
+            if (IsCtrlChecked) modifiers |= ModifierKeys.Control;
+            if (IsAltChecked) modifiers |= ModifierKeys.Alt;
+            if (IsShiftChecked) modifiers |= ModifierKeys.Shift;
+
+            _profile.HotkeyModifiers = modifiers;
+            _profile.HotkeyKey = _selectedKey;
+        }
+        else
+        {
+            _profile.HotkeyModifiers = null;
+            _profile.HotkeyKey = null;
+        }
+
+        Publish();
+    }
+
+    private void ClearHotkey()
+    {
+        _resetting = true;
+        IsCtrlChecked = false;
+        IsAltChecked = false;
+        IsShiftChecked = false;
+        SelectedKey = null;
+        _resetting = false;
+
+        _profile.HotkeyModifiers = null;
+        _profile.HotkeyKey = null;
+
+        Publish();
+    }
+
     private void SetOriginalSettings(ProfileSetting profileSetting)
     {
         _originalSettings = new ProfileSetting(profileSetting.Brightness, profileSetting.Contrast,
@@ -105,4 +227,23 @@ public class ProfileSettingViewModel : Screen, IHandle<RevertEvent>
     {
         SetOriginalSettings(ProfileSetting);
     }
+}
+
+public class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+
+    public RelayCommand(Action execute)
+    {
+        _execute = execute;
+    }
+
+    public bool CanExecute(object? parameter) => true;
+
+    public void Execute(object? parameter)
+    {
+        _execute();
+    }
+
+    public event EventHandler? CanExecuteChanged;
 }

--- a/NvidiaDisplayController/Interface/Profiles/ProfileViewModel.cs
+++ b/NvidiaDisplayController/Interface/Profiles/ProfileViewModel.cs
@@ -87,7 +87,7 @@ public class ProfileViewModel : Screen
     private void BuildProfileSettings()
     {
         ProfileSettings = _profileSettingViewModelFactory
-            .Create(Profile.ProfileSetting, Profile.IsDefault);
+            .Create(Profile.ProfileSetting, Profile.IsDefault, Profile);
     }
 
     public void IsUpdated()

--- a/NvidiaDisplayController/Interface/Shell/ShellView.xaml
+++ b/NvidiaDisplayController/Interface/Shell/ShellView.xaml
@@ -10,8 +10,9 @@
     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
     mc:Ignorable="d"
-    Height="580"
+    MinHeight="580"
     Width="600"
+    SizeToContent="Height"
     WindowStartupLocation="CenterScreen"
     WindowStyle="ToolWindow"
     ResizeMode="CanMinimize"
@@ -64,7 +65,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" MinHeight="130" />
-            <RowDefinition Height="175" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <StackPanel

--- a/NvidiaDisplayController/Interface/Shell/ShellView.xaml.cs
+++ b/NvidiaDisplayController/Interface/Shell/ShellView.xaml.cs
@@ -10,6 +10,8 @@ using NvidiaDisplayController.Global;
 using NvidiaDisplayController.Global.Controllers;
 using NvidiaDisplayController.Global.Extensions;
 using Application = System.Windows.Application;
+using System.Windows.Interop;
+using System.Windows.Input;
 
 namespace NvidiaDisplayController.Interface.Shell;
 
@@ -25,6 +27,15 @@ public partial class ShellView
 
     [Inject] public DataController DataController { get; set; } = null!;
 
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        // add message handler to listen for messages from other instances of the app
+        HwndSource source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        source.AddHook(WndProc);
+    }
+
     private void Start()
     {
         IoC.BuildUp(this);
@@ -32,6 +43,17 @@ public partial class ShellView
         CreateSystemTrayIcon();
 
         GlobalEvents.UpdateToolTip += OnUpdateToolTip;
+    }
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        // listen for the custom message and show the window contents
+        if (msg == 0x0400 + 1) // WM_SHOWME
+        {
+            DoShow();
+            handled = true;
+        }
+        return IntPtr.Zero;
     }
 
     private void OnUpdateToolTip()
@@ -44,6 +66,11 @@ public partial class ShellView
         _notifyIcon = new NotifyIcon();
         _notifyIcon.Icon = new Icon("Resources/desktop.ico");
         _notifyIcon.Visible = true;
+
+        // show the window when left clicking the tray icon
+        _notifyIcon.MouseClick += (s, e) => { 
+            if (e.Button == MouseButtons.Left) DoShow(); 
+        };
 
         _notifyIcon.ContextMenuStrip = new ContextMenuStrip();
         _notifyIcon.ContextMenuStrip.Items.Add("Show", null, OpenEvent);
@@ -80,10 +107,19 @@ public partial class ShellView
         DoShow();
     }
 
-    private void DoShow()
+    public void DoShow()
     {
         Show();
         WindowState = WindowState.Normal;
+
+        // ensure to focus the window so that it brings it to the front
+        Activate();
+        Focus();
+
+        // toggle topmost to bring it to the front above all other windows
+        // then disable so it behaves normally
+        Topmost = true;
+        Topmost = false;
     }
 
     protected override void OnStateChanged(EventArgs e)

--- a/NvidiaDisplayController/Interface/Shell/ShellViewModel.cs
+++ b/NvidiaDisplayController/Interface/Shell/ShellViewModel.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
 using Caliburn.Micro;
 using NLog;
 using NvAPIWrapper.Display;
@@ -41,6 +43,8 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
     private MonitorViewModel? _selectedMonitor;
     private Display? _selectedNvidiaMonitor;
     private ProfileViewModel? _selectedProfile;
+    private HotkeyManager? _hotkeyManager;
+    private readonly Dictionary<int, ProfileViewModel> _hotkeyToProfile = new();
 
     public ShellViewModel(
         IEventAggregator eventAggregator,
@@ -259,6 +263,9 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
     {
         profileViewModel.IsSelectedChanged += OnProfileViewModelSelectedChanged;
         profileViewModel.ProfileRemoved += OnProfileRemoved;
+        
+        // Register hotkey when profile is created/loaded
+        RegisterProfileHotkey(profileViewModel);
     }
 
     private void OnProfileViewModelSelectedChanged(Guid guid, bool value)
@@ -282,6 +289,9 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
     private void OnProfileRemoved(Guid guid)
     {
         var profileViewModel = SelectedMonitor!.Profiles.Single(p => p.Guid == guid);
+
+        // Unregister hotkey before removing profile
+        UnregisterProfileHotkey(profileViewModel);
 
         SelectedMonitor.Monitor.Profiles.Remove(profileViewModel.Profile);
         SelectedMonitor?.Profiles.Remove(profileViewModel);
@@ -369,6 +379,9 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
 
         SelectedProfile!.IsUpdated();
         ProfileSettingsIsDirty = false;
+        
+        // Re-register hotkey in case it changed
+        ReregisterProfileHotkey(SelectedProfile);
     }
 
     public void OpenHelp()
@@ -379,5 +392,103 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
     public void OpenDonation()
     {
         _nvidiaDisplayWindowManager.OpenWebsite(PaypalLink);
+    }
+
+    protected override void OnViewLoaded(object view)
+    {
+        base.OnViewLoaded(view);
+        InitializeHotkeyManager(view);
+    }
+
+    private void InitializeHotkeyManager(object view)
+    {
+        if (view is Window window)
+        {
+            var helper = new WindowInteropHelper(window);
+            _hotkeyManager = new HotkeyManager(helper.Handle);
+            
+            // Register hotkeys for all existing profiles
+            foreach (var monitor in Monitors)
+            {
+                foreach (var profile in monitor.Profiles)
+                {
+                    RegisterProfileHotkey(profile);
+                }
+            }
+        }
+    }
+
+    private void RegisterProfileHotkey(ProfileViewModel profileViewModel)
+    {
+        if (profileViewModel.Profile.HotkeyModifiers.HasValue && 
+            profileViewModel.Profile.HotkeyKey.HasValue &&
+            _hotkeyManager != null)
+        {
+            var hotkeyId = _hotkeyManager.RegisterHotkey(
+                profileViewModel.Profile.HotkeyModifiers.Value,
+                profileViewModel.Profile.HotkeyKey.Value,
+                () => ActivateProfile(profileViewModel));
+
+            if (hotkeyId != -1)
+            {
+                _hotkeyToProfile[hotkeyId] = profileViewModel;
+            }
+            else
+            {
+                _logger.Warn($"Failed to register hotkey for profile: {profileViewModel.Name}");
+            }
+        }
+    }
+
+    private void UnregisterProfileHotkey(ProfileViewModel profileViewModel)
+    {
+        if (_hotkeyManager != null)
+        {
+            var hotkeyId = _hotkeyToProfile.FirstOrDefault(x => x.Value == profileViewModel).Key;
+            if (hotkeyId != 0)
+            {
+                _hotkeyManager.UnregisterHotkey(hotkeyId);
+                _hotkeyToProfile.Remove(hotkeyId);
+            }
+        }
+    }
+
+    private void ReregisterProfileHotkey(ProfileViewModel profileViewModel)
+    {
+        UnregisterProfileHotkey(profileViewModel);
+        RegisterProfileHotkey(profileViewModel);
+    }
+
+    private void ActivateProfile(ProfileViewModel profileViewModel)
+    {
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            try
+            {
+                var monitor = Monitors.FirstOrDefault(m => m.Profiles.Contains(profileViewModel));
+                if (monitor != null)
+                {
+                    var nvidiaDisplay = _nvidiaDisplays?.SingleOrDefault(d => d.Name == monitor.ScreenName);
+                    
+                    _displayController.UpdateColorSettings(
+                        monitor.Display,
+                        profileViewModel.ProfileSettings!.ProfileSetting,
+                        nvidiaDisplay);
+
+                    profileViewModel.IsActive = true;
+                    foreach (var otherProfile in monitor.Profiles.Where(p => p.Guid != profileViewModel.Guid))
+                    {
+                        otherProfile.Deactivate();
+                    }
+
+                    Write();
+                    GlobalEvents.UpdateToolTip.Invoke();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error activating profile via hotkey");
+            }
+        });
     }
 }

--- a/NvidiaDisplayController/Interface/Shell/ShellViewModel.cs
+++ b/NvidiaDisplayController/Interface/Shell/ShellViewModel.cs
@@ -19,6 +19,8 @@ using NvidiaDisplayController.Objects.Entities;
 using NvidiaDisplayController.Objects.Factories;
 using NvidiaDisplayController.Objects.Factories.Interfaces;
 using NvidiaDisplayController.Objects.HandleEvents;
+using System.Windows.Input;
+using NHotkey.Wpf;
 using Monitor = NvidiaDisplayController.Objects.Entities.Monitor;
 
 namespace NvidiaDisplayController.Interface.Shell;
@@ -405,7 +407,7 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
         if (view is Window window)
         {
             var helper = new WindowInteropHelper(window);
-            _hotkeyManager = new HotkeyManager(helper.Handle);
+            _hotkeyManager = HotkeyManager.Current;
             
             // Register hotkeys for all existing profiles
             foreach (var monitor in Monitors)
@@ -424,18 +426,23 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
             profileViewModel.Profile.HotkeyKey.HasValue &&
             _hotkeyManager != null)
         {
-            var hotkeyId = _hotkeyManager.RegisterHotkey(
-                profileViewModel.Profile.HotkeyModifiers.Value,
-                profileViewModel.Profile.HotkeyKey.Value,
-                () => ActivateProfile(profileViewModel));
+            try
+            {
+                var keyGesture = new KeyGesture(
+                    profileViewModel.Profile.HotkeyKey.Value,
+                    profileViewModel.Profile.HotkeyModifiers.Value);
+                
+                string hotkeyID = profileViewModel.Guid.ToString();
+                _hotkeyManager.AddOrReplace(
+                    profileViewModel.Name, 
+                    keyGesture, 
+                    (s, e) => ActivateProfile(profileViewModel)); 
 
-            if (hotkeyId != -1)
-            {
-                _hotkeyToProfile[hotkeyId] = profileViewModel;
+                _hotkeyToProfile[profileViewModel.Guid.ToString().GetHashCode()] = profileViewModel;
             }
-            else
+            catch (Exception ex)
             {
-                _logger.Warn($"Failed to register hotkey for profile: {profileViewModel.Name}");
+                _logger.Warn($"Failed to register hotkey for profile: {profileViewModel.Name}. Error: {ex.Message}");
             }
         }
     }
@@ -444,12 +451,10 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
     {
         if (_hotkeyManager != null)
         {
-            var hotkeyId = _hotkeyToProfile.FirstOrDefault(x => x.Value == profileViewModel).Key;
-            if (hotkeyId != 0)
-            {
-                _hotkeyManager.UnregisterHotkey(hotkeyId);
-                _hotkeyToProfile.Remove(hotkeyId);
-            }
+            _hotkeyManager.Remove(profileViewModel.Guid.ToString());
+            
+            var hashCode = profileViewModel.Guid.ToString().GetHashCode();
+            _hotkeyToProfile.Remove(hashCode);
         }
     }
 
@@ -472,7 +477,7 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
                     
                     _displayController.UpdateColorSettings(
                         monitor.Display,
-                        profileViewModel.ProfileSettings!.ProfileSetting,
+                        profileViewModel.Profile.ProfileSetting, 
                         nvidiaDisplay);
 
                     profileViewModel.IsActive = true;
@@ -481,7 +486,7 @@ public class ShellViewModel : Conductor<IScreen>, IHandle<ProfileSettingsEvent>
                         otherProfile.Deactivate();
                     }
 
-                    Write();
+                    Write(); // Save the state
                     GlobalEvents.UpdateToolTip.Invoke();
                 }
             }

--- a/NvidiaDisplayController/NvidiaDisplayController.csproj
+++ b/NvidiaDisplayController/NvidiaDisplayController.csproj
@@ -12,6 +12,7 @@
         <FileVersion>1.0.0.0</FileVersion>
         <Title>Nvidia Display Controller</Title>
         <RepositoryUrl>https://github.com/therealmariolaurianti/NvidiaDisplayController</RepositoryUrl>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NvidiaDisplayController/NvidiaDisplayController.csproj
+++ b/NvidiaDisplayController/NvidiaDisplayController.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="MahApps.Metro" Version="2.4.10" />
         <PackageReference Include="MahApps.Metro.IconPacks" Version="4.11.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="NHotkey.Wpf" Version="4.0.0" />
         <PackageReference Include="Ninject" Version="3.3.6" />
         <PackageReference Include="ninject.extensions.conventions" Version="3.3.0" />
         <PackageReference Include="Ninject.Extensions.Factory" Version="3.3.3" />

--- a/NvidiaDisplayController/Objects/Entities/Profile.cs
+++ b/NvidiaDisplayController/Objects/Entities/Profile.cs
@@ -1,4 +1,6 @@
-﻿namespace NvidiaDisplayController.Objects.Entities;
+﻿using System.Windows.Input;
+
+namespace NvidiaDisplayController.Objects.Entities;
 
 public class Profile
 {
@@ -17,4 +19,8 @@ public class Profile
     public ProfileSetting ProfileSetting { get; }
     public bool IsActive { get; set; }
     public bool IsDefault { get; set; }
+    
+    // Hotkey properties
+    public ModifierKeys? HotkeyModifiers { get; set; }
+    public Key? HotkeyKey { get; set; }
 }

--- a/NvidiaDisplayController/Objects/Factories/Interfaces/IProfileSettingViewModelFactory.cs
+++ b/NvidiaDisplayController/Objects/Factories/Interfaces/IProfileSettingViewModelFactory.cs
@@ -5,5 +5,5 @@ namespace NvidiaDisplayController.Objects.Factories.Interfaces;
 
 public interface IProfileSettingViewModelFactory : IFactory
 {
-    ProfileSettingViewModel Create(ProfileSetting profileSetting, bool isDefault);
+    ProfileSettingViewModel Create(ProfileSetting profileSetting, bool isDefault, Profile profile);
 }

--- a/WindowsDisplayAPI-master/WindowsDisplayAPI/WindowsDisplayAPI.csproj
+++ b/WindowsDisplayAPI-master/WindowsDisplayAPI/WindowsDisplayAPI.csproj
@@ -31,12 +31,6 @@
         <DocumentationFile>..\Release\WindowsDisplayAPI.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference PrivateAssets="all" Include="MSBump" Version="2.3.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
         <Content Include="readme.txt">
             <Pack>true</Pack>
             <PackagePath>\</PackagePath>


### PR DESCRIPTION
The original PR or sample for Keyboard shortcuts didn't seem to work as it kept having build errors. 

This PR: 
- Fixes the errors and gets things building ✅
- Adjusts the Window size and Profile section content size to grow with the content (we should avoid hardcoded heights) 🛠
- Extends the keyboard shortcut globally across Windows, instead of only being able to apply when you're in the profile you want to use the keyboard shortcut for 😂

I set one profile to normal with CTRL-ALT-F1, and set my Tarkov profile to CTRL-ALT-F2. 
As long as the app is in the tray, I can now switch profiles on the fly super easily! 

This PR also includes the previous usability fixes https://github.com/therealmariolaurianti/NvidiaDisplayController/pull/5 
- If the app is open, whether the app is minimized to tray or out of focus somewhere, and you open the app again, it now finds the current running instance, activates it, and brings it into focus. 
- If the app is in the tray, left clicking will open and focus the app.